### PR TITLE
Implement Feature Request #5 from Deerhound579/mcgill-course-map

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ plotly==4.3.0
 retrying==1.3.3
 six==1.13.0
 Werkzeug==0.16.0
+SecretColors==1.1.0


### PR DESCRIPTION
This patch renamed the ratio button "Path by course" and added a new one "Prerequisites that you need for this course."

Note that this patch introduces a bug to the program. After switching to the `overview` mode using the ratio buttons, it is no longer possible to switch back to `course` or `prerequisite`. Please look into this issue.

Please refer to issue  #5 for a demonstration of this patch.